### PR TITLE
Tweak install docs to work

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Install
 If you use Pathogen, you can just clone this into your bundles
 
 ```bash
-cd ~/.vim/bundles
-git clone git:github.com/jtratner/vim-flavored-markdown.git
+cd ~/.vim/bundle
+git clone git@github.com:jtratner/vim-flavored-markdown.git
 ```
 
 ### Otherwise, copy the file to your syntax folder


### PR DESCRIPTION
So there were just a couple of tweaks needed to make the 'how to install' text match what was needed.  Made 'em.
