### PR TITLE
GFM supports arbitrary characters in fenced code block language identifier.

### DIFF
--- a/syntax/ghmarkdown.vim
+++ b/syntax/ghmarkdown.vim
@@ -75,7 +75,7 @@ syn region markdownCode matchgroup=markdownCodeDelimiter start="`` \=" end=" \=`
 syn match markdownEscape "\\[][\\`*_{}()#+.!-]"
 
 syn cluster markdownBlock contains=markdownH1,markdownH2,markdownH3,markdownH4,markdownH5,markdownH6,markdownBlockquote,markdownListMarker,markdownOrderedListMarker,markdownCodeBlock,markdownRule, markdownGHCodeBlock
-syn region markdownGHCodeBlock matchgroup=markdownCodeDelimiter start="^\s*$\n```\w*\s*$" end="```$\n\s*\n" contained  keepend
+syn region markdownGHCodeBlock matchgroup=markdownCodeDelimiter start="^\s*$\n```\S*\s*$" end="```$\n\s*\n" contained  keepend
 " Copying rst's method of using literal strings
 hi def link markdownGHCodeBlock           String
 hi def link markdownCodeBlock             String


### PR DESCRIPTION
``` this:is:a:test:with:the:snowman:☃:
Yep it works
```

GFM supports arbitrary characters in fenced code block language identifier.  Changed a \w to a \S in the markdownGHCodeBlock section
