### PR TITLE
"``` vim" is correct as "```vim"

### DIFF
--- a/syntax/ghmarkdown.vim
+++ b/syntax/ghmarkdown.vim
@@ -75,7 +75,7 @@ syn region markdownCode matchgroup=markdownCodeDelimiter start="`` \=" end=" \=`
 syn match markdownEscape "\\[][\\`*_{}()#+.!-]"
 
 syn cluster markdownBlock contains=markdownH1,markdownH2,markdownH3,markdownH4,markdownH5,markdownH6,markdownBlockquote,markdownListMarker,markdownOrderedListMarker,markdownCodeBlock,markdownRule, markdownGHCodeBlock
-syn region markdownGHCodeBlock matchgroup=markdownCodeDelimiter start="^\s*$\n```\S*\s*$" end="```$\n\s*\n" contained  keepend
+syn region markdownGHCodeBlock matchgroup=markdownCodeDelimiter start="^\s*$\n```\s{0,1}\S*\s*$" end="```$\n\s*\n" contained  keepend
 " Copying rst's method of using literal strings
 hi def link markdownGHCodeBlock           String
 hi def link markdownCodeBlock             String


### PR DESCRIPTION
Now:

``````
``` js
  var bad = true
```

Some text.
``````

... result: 

![Screen Shot 2013-04-06 at 1 28 59 PM](https://f.cloud.github.com/assets/52201/346960/4ef0afb0-9e83-11e2-8b48-151d8c51da45.png)
