### PR TITLE
Allow whitespace before code block backticks.

### DIFF
--- a/syntax/ghmarkdown.vim
+++ b/syntax/ghmarkdown.vim
@@ -74,7 +74,7 @@ syn region markdownBoldItalic start="\<\*\*\*\|\*\*\*\>" end="\<\*\*\*\|\*\*\*\>
 syn region markdownBoldItalic start="\<___\|___\>" end="\<___\|___\>" keepend contains=markdownLineStart
 syn region markdownCode matchgroup=markdownCodeDelimiter start="`" end="`" keepend contains=markdownLineStart
 syn region markdownCode matchgroup=markdownCodeDelimiter start="`` \=" end=" \=``" keepend contains=markdownLineStart
-syn region markdownGHCodeBlock matchgroup=markdownCodeDelimiter start="^\s*$\n```\s\?\S*\s*$" end="```$\n\s*\n" contained  keepend
+syn region markdownGHCodeBlock matchgroup=markdownCodeDelimiter start="^\s*$\n\s*```\s\?\S*\s*$" end="\s*```$\n\s*\n" contained  keepend
 
 syn match markdownEscape "\\[][\\`*_{}()#+.!-]"
 


### PR DESCRIPTION
Fixes #11.

@rouge8 - this fixes your example for me, does it work for you?
