### PR TITLE
Tripple ` for named markdownCodeDelimiter

### DIFF
--- a/syntax/ghmarkdown.vim
+++ b/syntax/ghmarkdown.vim
@@ -73,7 +73,7 @@ syn region markdownBold start="\<__\|__\>" end="\<__\|__\>" keepend contains=mar
 syn region markdownBoldItalic start="\<\*\*\*\|\*\*\*\>" end="\<\*\*\*\|\*\*\*\>" keepend contains=markdownLineStart
 syn region markdownBoldItalic start="\<___\|___\>" end="\<___\|___\>" keepend contains=markdownLineStart
 syn region markdownCode matchgroup=markdownCodeDelimiter start="`" end="`" keepend contains=markdownLineStart
-syn region markdownCode matchgroup=markdownCodeDelimiter start="`` \=" end=" \=``" keepend contains=markdownLineStart
+syn region markdownCode matchgroup=markdownCodeDelimiter start="``` \=" end=" \=```" keepend contains=markdownLineStart
 syn region markdownGHCodeBlock matchgroup=markdownCodeDelimiter start="^\s*$\n\s*```\s\?\S*\s*$" end="\s*```$\n\s*\n" contained  keepend
 
 syn match markdownEscape "\\[][\\`*_{}()#+.!-]"


### PR DESCRIPTION
Having some syntax highlighting issues where vim doesn't understand where codeblocks end. Fixed by supporting the de-factor tripple ` syntax.

Before
![screen shot 2014-11-10 at 11 20 34 am](https://cloud.githubusercontent.com/assets/362269/4979215/878beedc-68f5-11e4-8685-06c20b3bcdde.png)

After
![screen shot 2014-11-10 at 11 20 15 am](https://cloud.githubusercontent.com/assets/362269/4979217/8b60884c-68f5-11e4-949d-4c00e9da6942.png)

