### PR TITLE
Fix #15, bold formatting with asterisks (``*'')

### DIFF
--- a/syntax/ghmarkdown.vim
+++ b/syntax/ghmarkdown.vim
@@ -66,12 +66,12 @@ syn region markdownLink matchgroup=markdownLinkDelimiter start="(" end=")" conta
 syn region markdownId matchgroup=markdownIdDelimiter start="\[" end="\]" keepend contained
 syn region markdownAutomaticLink matchgroup=markdownUrlDelimiter start="<\%(\w\+:\|[[:alnum:]_+-]\+@\)\@=" end=">" keepend oneline
 
-syn region markdownItalic start="\<\*\|\*\>" end="\<\*\|\*\>" keepend contains=markdownLineStart
-syn region markdownItalic start="\<_\|_\>" end="\<_\|_\>" keepend contains=markdownLineStart
-syn region markdownBold start="\<\*\*\|\*\*\>" end="\<\*\*\|\*\*\>" keepend contains=markdownLineStart,markdownItalic
-syn region markdownBold start="\<__\|__\>" end="\<__\|__\>" keepend contains=markdownLineStart,markdownItalic
-syn region markdownBoldItalic start="\<\*\*\*\|\*\*\*\>" end="\<\*\*\*\|\*\*\*\>" keepend contains=markdownLineStart
-syn region markdownBoldItalic start="\<___\|___\>" end="\<___\|___\>" keepend contains=markdownLineStart
+syn region markdownItalic start="\S\@<=\*\|\*\S\@=" end="\S\@<=\*\|\*\S\@=" keepend contains=markdownLineStart
+syn region markdownItalic start="\S\@<=_\|_\S\@=" end="\S\@<=_\|_\S\@=" keepend contains=markdownLineStart
+syn region markdownBold start="\S\@<=\*\*\|\*\*\S\@=" end="\S\@<=\*\*\|\*\*\S\@=" keepend contains=markdownLineStart
+syn region markdownBold start="\S\@<=__\|__\S\@=" end="\S\@<=__\|__\S\@=" keepend contains=markdownLineStart
+syn region markdownBoldItalic start="\S\@<=\*\*\*\|\*\*\*\S\@=" end="\S\@<=\*\*\*\|\*\*\*\S\@=" keepend contains=markdownLineStart
+syn region markdownBoldItalic start="\S\@<=___\|___\S\@=" end="\S\@<=___\|___\S\@=" keepend contains=markdownLineStart
 syn region markdownCode matchgroup=markdownCodeDelimiter start="`" end="`" keepend contains=markdownLineStart
 syn region markdownCode matchgroup=markdownCodeDelimiter start="``` \=" end=" \=```" keepend contains=markdownLineStart
 syn region markdownGHCodeBlock matchgroup=markdownCodeDelimiter start="^\s*$\n\s*```\s\?\S*\s*$" end="\s*```$\n\s*\n" contained  keepend


### PR DESCRIPTION
This commit reenables emphasis highlighting for Markdown text that
is fenced by asterisks, *like so*.
It actually updates the definitions for regions `markdownItalic`,
`markdownBold`, `markdownBoldItalic`, and `markdownCode` from @tpope's
`markdown.vim` from 2010-05-21 (which I had lying around locally).

A quick local test indicates that the patch works as intended, albeit
with slight changes in appearance of formatted text:

Example  -- previous style -- current style
*word*   -- no formatting  -- italic (as planned)
_word_   -- italic         -- italic
**word** -- no formatting  -- bold
__word__ -- italic         -- bold (see below)

Formatting double-underscore as bold follows GitHub's style, see
https://help.github.com/articles/basic-writing-and-formatting-syntax/

Note: tpope/vim-markdown@a7dbc314569aa85db80c106d73b1664e385b6ae7 would
be the current up-to-date version of the base plugin, but there have
been changes to it that look incompatible with the rest of what's here
so I'm basing my work on the old version instead.